### PR TITLE
Expose markdown-it enable/disable methods in loader options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ module.exports = {
 * `passElementProps`: Controls whether props can be passed from the parent to the generated elements. Defaults to `false`.
 * `implicitlyImportReact`: Whether to include React and PropTypes in the imports automatically. If set to `false`, you need to either supply React and PropTypes or import them explicitly. Defaults to `true`.
 * `markdownItPlugins`: An array of [MarkdownIt plugins](https://www.npmjs.org/browse/keyword/markdown-it-plugin) (and optionally their additional arguments) to use within the markdown renderer. These can be specified either as instances, or as paths as returned by `require.resolve`.
+* `enabledMarkdownItRules`: An array of [MarkdownIt rules](https://github.com/markdown-it/markdown-it/blob/master/lib/parser_block.js) the loader should enable on the renderer. Defaults to `['smartquotes']`.
+* `disabledMarkdownItRules`: An array of MarkdownIt rules the loader should disable on the renderer (for disabling default rules).
 
 ##### MarkdownIt Plugins
 
@@ -151,7 +153,8 @@ If you supply an array of [MarkdownIt plugins](https://www.npmjs.org/browse/keyw
     markdownItPlugins: [
       require('markdown-it-anchor'),
       [require('markdown-it-table-of-contents'), { containerClass: 'my-container-class' }]
-    ]
+    ],
+    enabledMarkdownItRules: ['smartquotes', 'table'],
   },
   {...more}
 }

--- a/src/__snapshots__/convert.spec.js.snap
+++ b/src/__snapshots__/convert.spec.js.snap
@@ -297,6 +297,91 @@ exports[`convert accepts plugins specified as a string renders as expected withi
 </div>
 `;
 
+exports[`convert accepts rules to disable as an array has the expected preamble 1`] = `
+"
+import React from 'react';
+import PropTypes from 'prop-types';
+
+MarkdownComponent.propTypes = {
+  className: PropTypes.string,
+  style: PropTypes.object
+};
+
+"
+`;
+
+exports[`convert accepts rules to disable as an array renders as expected within React 1`] = `
+Object {
+  "propTypes": Object {
+    "className": [Function],
+    "style": [Function],
+  },
+}
+`;
+
+exports[`convert accepts rules to disable as an array renders as expected within React 2`] = `
+<div
+  className={undefined}
+  style={undefined}
+>
+  <p>
+    'single-quoted'
+  </p>
+</div>
+`;
+
+exports[`convert accepts rules to enable as an array has the expected preamble 1`] = `
+"
+import React from 'react';
+import PropTypes from 'prop-types';
+
+MarkdownComponent.propTypes = {
+  className: PropTypes.string,
+  style: PropTypes.object
+};
+
+"
+`;
+
+exports[`convert accepts rules to enable as an array renders as expected within React 1`] = `
+Object {
+  "propTypes": Object {
+    "className": [Function],
+    "style": [Function],
+  },
+}
+`;
+
+exports[`convert accepts rules to enable as an array renders as expected within React 2`] = `
+<div
+  className={undefined}
+  style={undefined}
+>
+  <table>
+    <thead>
+      <tr>
+        <th>
+          hdr1
+        </th>
+        <th>
+          hdr2
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          val1
+        </td>
+        <td>
+          val2
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`convert doesn't trigger any kind of comment highlighting in highlights has the expected preamble 1`] = `
 "
 import React from 'react';

--- a/src/convert.js
+++ b/src/convert.js
@@ -26,7 +26,9 @@ const IMPLICIT_REACT_IMPORTS = {
 const DEFAULT_CONFIGURATION = {
   implicitlyImportReact: true,
   passElementProps: false,
-  markdownItPlugins: []
+  markdownItPlugins: [],
+  enabledMarkdownItRules: ['smartquotes'],
+  disabledMarkdownItRules: []
 };
 
 export default (source, config) => {
@@ -104,7 +106,8 @@ export default (source, config) => {
   // Configure Markdown renderer, highlight code snippets, and post-process
   let renderer = new MarkdownIt()
     .configure('commonmark')
-    .enable(['smartquotes'])
+    .enable(config.enabledMarkdownItRules)
+    .disable(config.disabledMarkdownItRules)
     .set({
       // We need explicit line breaks
       breaks: true,

--- a/src/convert.spec.js
+++ b/src/convert.spec.js
@@ -233,4 +233,22 @@ describe('convert', () => {
       }
     );
   });
+
+  describe('accepts rules to enable as an array', () => {
+    let docText = DocChomp`
+      | hdr1 | hdr2 |
+      | ---- | ---- |
+      | val1 | val2 |
+    `;
+
+    RUN_ONE_FIXTURE(docText, {enabledMarkdownItRules: ['table']});
+  });
+
+  describe('accepts rules to disable as an array', () => {
+    let docText = "'single-quoted'";
+
+    // Disabling overrides enabling.
+    RUN_ONE_FIXTURE(docText, {enabledMarkdownItRules: ['smartquotes'], disabledMarkdownItRules: ['smartquotes']});
+  });
+
 });

--- a/src/convert.spec.js
+++ b/src/convert.spec.js
@@ -235,20 +235,20 @@ describe('convert', () => {
   });
 
   describe('accepts rules to enable as an array', () => {
-    let docText = DocChomp`
+    const docText = DocChomp`
       | hdr1 | hdr2 |
       | ---- | ---- |
       | val1 | val2 |
     `;
 
-    RUN_ONE_FIXTURE(docText, {enabledMarkdownItRules: ['table']});
+    RUN_ONE_FIXTURE(docText, { enabledMarkdownItRules: ['table'] });
   });
 
   describe('accepts rules to disable as an array', () => {
-    let docText = "'single-quoted'";
+    const docText = "'single-quoted'";
 
     // Disabling overrides enabling.
-    RUN_ONE_FIXTURE(docText, {enabledMarkdownItRules: ['smartquotes'], disabledMarkdownItRules: ['smartquotes']});
+    RUN_ONE_FIXTURE(docText, { enabledMarkdownItRules: ['smartquotes'], disabledMarkdownItRules: ['smartquotes'] });
   });
 
 });


### PR DESCRIPTION
This allows the component options to specify markdown-it rules to enable or disable. I needed this to take advantage of the default table support. I spent a while looking at markdown-it plugins that support different table syntaxes. It looks like they all override the basic table support, so using them from the component loader would depend on the rule being enabled.